### PR TITLE
Expand relative dates for time-ago elements

### DIFF
--- a/process-dates.js
+++ b/process-dates.js
@@ -1,4 +1,4 @@
-var elements = document.querySelectorAll('relative-time');
+var elements = document.querySelectorAll('relative-time, time-ago');
 
 for (var i in elements) {
     var el = elements[i];


### PR DESCRIPTION
This extension targets relative-time elements, but on the landing page
for a repository, the dates listed next to each file are actually
time-ago elements.
